### PR TITLE
make module list a global

### DIFF
--- a/lib/atom-amdbutler.js
+++ b/lib/atom-amdbutler.js
@@ -27,6 +27,7 @@ module.exports =  {
         this.modsView = new ModsView();
 
         this.subscriptions = new CompositeDisposable();
+
         return this.subscriptions.add(
             atom.commands.add('atom-workspace', {
                 'amdbutler:add': this.add.bind(this),
@@ -53,15 +54,6 @@ module.exports =  {
         // create a checkpoint to allow for a single undo for this entire operation
         var checkPoint = buffer.createCheckpoint();
 
-        // remove added item from mods available for adding again
-        var i;
-        buffer.__mods.forEach(function (m, x) {
-            if (m === item) {
-                i = x;
-            }
-        });
-        buffer.__mods.splice(i, 1);
-
         // add pair
         var paramsPoint = bufferParser.getParamsRange(buffer).start;
         buffer.insert(paramsPoint, item.name + ',');
@@ -76,11 +68,6 @@ module.exports =  {
         var buffer = atom.workspace.getActivePaneItem().buffer;
 
         var checkPoint = buffer.createCheckpoint();
-
-        // add item back into available mods for this buffer
-        if (buffer.__mods) {
-            buffer.__mods.push(item);
-        }
 
         var pairs = this.getSortedPairs(buffer);
         this.updateWithPairs(buffer, pairs.filter(function (p) {
@@ -104,23 +91,26 @@ module.exports =  {
 
         buffer.groupChangesSinceCheckpoint(checkPoint);
     },
+    ensureModulesAreLoaded: function (bufferPath) {
+        if (!this.modules) {
+            this.modules = crawler.crawl(
+                crawler.getBaseFolderPath(bufferPath, atom.config.get('amdbutler.baseFolders'))
+            );
+        }
+    },
 
     // commands
     add: function () {
         console.log('amdbutler:add');
         var buffer = atom.workspace.getActivePaneItem().buffer;
 
-        // this could maybe go in the activate method then recrawl async
-        // on changes to base folder
-        if (!buffer.__mods) {
-            buffer.__mods = crawler.crawl(
-                crawler.getBaseFolderPath(buffer.getPath(),
-                atom.config.get('amdbutler.baseFolders')),
-                this.getSortedPairs(buffer)
-            );
-        }
+        this.ensureModulesAreLoaded(buffer.getPath());
 
-        this.modsView.show(buffer.__mods, 'add');
+        var excludes = this.getSortedPairs(buffer).map(function (i) {
+            return i.path;
+        });
+
+        this.modsView.show(this.modules, 'add', excludes);
     },
     sort: function () {
         console.log('amdbutler:sort');

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -25,14 +25,12 @@ module.exports = {
 
         return path.join(filePath.split(baseFolderName)[0], baseFolderName);
     },
-    crawl: function (basePath, excludes) {
+    crawl: function (basePath) {
         var defaultExcludes = ['**/nls/**', '**/tests/**'];
         var options = {
             cwd: basePath,
             nodir: true,
-            ignore: excludes.map(function (ex) {
-                return ex.path + '.js';
-            }).concat(defaultExcludes)
+            ignore: defaultExcludes
         };
 
         var that = this;

--- a/lib/mods-view.js
+++ b/lib/mods-view.js
@@ -50,7 +50,9 @@ ModsView.prototype.hide = function () {
     this.panel.hide();
     this.restoreFocus();
 };
-ModsView.prototype.show = function (items, action) {
+ModsView.prototype.show = function (items, action, excludePaths) {
+    console.log('show', arguments);
+    excludePaths = (excludePaths) ? excludePaths : [];
     this.action = action;
     this.storeFocusedElement();
     if (this.panel == null) {
@@ -59,7 +61,9 @@ ModsView.prototype.show = function (items, action) {
         });
     }
     this.panel.show();
-    this.setItems(items);
+    this.setItems(items.filter(function (i) {
+        return excludePaths.indexOf(i.path) === -1;
+    }));
     return this.focusFilterEditor();
 };
 ModsView.prototype.destroy = function () {

--- a/spec/crawler-spec.js
+++ b/spec/crawler-spec.js
@@ -33,14 +33,6 @@ describe('crawler tests', function () {
 
             expect(result.length).toBe(7);
         });
-        it('handles excludes', function () {
-            var exclude = {path: 'test/sub/ModuleTest', name: 'ModuleTest'};
-            var result = crawler.crawl(folder, [exclude]);
-
-            expect(result.every(function (item) {
-                return item.name !== exclude.name && item.path !== exclude.path;
-            })).toBe(true);
-        });
         it('gets param name', function () {
             expect(crawler.getParamName('test/dom-style')).toEqual('domStyle');
             expect(crawler.getParamName('test/window')).toEqual('testWindow');


### PR DESCRIPTION
This moves the module list to be a global list on the package object rather than a separate list for each buffer that is opened.

We still need to add logic to watch for file changes and update the list but I believe that this improvement can stand on it's own for now.
