### PR TITLE
Option to disable separation of package groups

### DIFF
--- a/lib/atom-amdbutler.js
+++ b/lib/atom-amdbutler.js
@@ -14,6 +14,11 @@ module.exports =  {
             items: {
                 type: 'string'
             }
+        },
+        separatePackages: {
+            type: 'boolean',
+            'default': true,
+            description: 'If you want to separate groups of modules from packages with an additional newline.'
         }
     },
 
@@ -80,10 +85,10 @@ module.exports =  {
         var importsRange = bufferParser.getImportsRange(buffer);
         var paramsRange = bufferParser.getParamsRange(buffer);
 
-        var paramsTxt = zipper.generateParamsTxt(pairs, '    ', false);
+        var paramsTxt = zipper.generateParamsTxt(pairs, '    ', false, atom.config.get('amdbutler.separatePackages'));
         buffer.setTextInRange(paramsRange, paramsTxt);
 
-        var importsTxt = zipper.generateImportsTxt(pairs, '    ');
+        var importsTxt = zipper.generateImportsTxt(pairs, '    ', atom.config.get('amdbutler.separatePackages'));
         buffer.setTextInRange(importsRange, importsTxt);
     },
     _sort: function (buffer, checkPoint) {

--- a/lib/zipper.js
+++ b/lib/zipper.js
@@ -42,7 +42,7 @@ module.exports = {
         });
         return pairs.concat(noParams);
     },
-    generateImportsTxt: function (pairs, indent) {
+    generateImportsTxt: function (pairs, indent, separatePackages) {
         var currentPackage;
         var txt = '';
         var NOPARAM = 'NOPARAM';
@@ -51,7 +51,7 @@ module.exports = {
             if (!currentPackage) {
                 currentPackage = newPackage;
             } else if (currentPackage !== newPackage && currentPackage !== NOPARAM) {
-                txt += ',\n';
+                txt += ',' + (separatePackages ? '\n' : '');
                 if (p.name) {
                     currentPackage = newPackage;
                 } else {
@@ -67,10 +67,10 @@ module.exports = {
 
         return txt;
     },
-    generateParamsTxt: function (pairs, indent, oneLine) {
+    generateParamsTxt: function (pairs, indent, oneLine, separatePackages) {
         // normal settings
         var initialTxt = '';
-        var endLineTxt = ',\n';
+        var endLineTxt = separatePackages ? ',\n' : ',';
         var afterItemTxt = ',';
         var everyIterTxt = '\n' + indent;
 

--- a/spec/data/imports_txt_no_separation
+++ b/spec/data/imports_txt_no_separation
@@ -1,0 +1,16 @@
+
+    'dijit/_TemplatedMixin',
+    'dijit/_WidgetBase',
+    'dijit/_WidgetsInTemplateMixin',
+    'dojo/_base/array',
+    'dojo/_base/Color',
+    'dojo/_base/declare',
+    'dojo/_base/lang',
+    'dojo/dom-class',
+    'dojo/dom-style',
+    'dojo/has',
+    'dojo/keys',
+    'dojo/on',
+    'dojo/text!app/templates/GeoSearch.html',
+    'dijit/form/ValidationTextBox',
+    'dojo/domReady!'

--- a/spec/data/params_txt_no_separation
+++ b/spec/data/params_txt_no_separation
@@ -1,0 +1,14 @@
+
+    _TemplatedMixin,
+    _WidgetBase,
+    _WidgetsInTemplateMixin,
+    array,
+    Color,
+    declare,
+    lang,
+    domClass,
+    domStyle,
+    has,
+    keys,
+    on,
+    template

--- a/spec/zipper-spec.js
+++ b/spec/zipper-spec.js
@@ -67,21 +67,39 @@ describe('zipper tests', function () {
     });
     describe('generateImportsText', function () {
         it('generates the appropriate imports text', function () {
-            var result = zipper.generateImportsTxt(pairs, '    ');
+            var result = zipper.generateImportsTxt(pairs, '    ', true);
             var expected = fs.readFileSync(path.join(__dirname, 'data', 'imports_txt'), readOptions);
+
+            expect(result).toEqual(expected);
+        });
+        it('generates the appropriate imports text with no package separation', function () {
+            var result = zipper.generateImportsTxt(pairs, '    ', false);
+            var expected = fs.readFileSync(path.join(__dirname, 'data', 'imports_txt_no_separation'), readOptions);
 
             expect(result).toEqual(expected);
         });
     });
     describe('generateParamsTxt', function () {
         it('generates the appropriate params text', function () {
-            var result = zipper.generateParamsTxt(pairs, '    ', false);
+            var result = zipper.generateParamsTxt(pairs, '    ', false, true);
             var expected = fs.readFileSync(path.join(__dirname, 'data', 'params_txt'), readOptions);
 
             expect(result).toEqual(expected);
         });
+        it('generates the appropriate params text with no package separation', function () {
+            var result = zipper.generateParamsTxt(pairs, '    ', false, false);
+            var expected = fs.readFileSync(path.join(__dirname, 'data', 'params_txt_no_separation'), readOptions);
+
+            expect(result).toEqual(expected);
+        });
         it('supports oneline option', function () {
-            var result = zipper.generateParamsTxt(pairs, '    ', true);
+            var result = zipper.generateParamsTxt(pairs, '    ', true, true);
+            var expected = fs.readFileSync(path.join(__dirname, 'data', 'params_txt_oneline'), readOptions);
+
+            expect(result).toEqual(expected);
+        });
+        it('supports oneline option, ignores no separation option', function () {
+            var result = zipper.generateParamsTxt(pairs, '    ', true, false);
             var expected = fs.readFileSync(path.join(__dirname, 'data', 'params_txt_oneline'), readOptions);
 
             expect(result).toEqual(expected);


### PR DESCRIPTION
Implement no separation feature as option, keeps default behaviour of separation.

Decided to not disable separation of groups when oneLine, not sure about what you want? it might produce very long lines in oneLine mode. Anyway I see that it is hardcoded to true now, so left it as is.

Added options in the setting panel:

![image](https://cloud.githubusercontent.com/assets/230877/11452313/9f672bb8-95e3-11e5-980e-99db8771a476.png)
