### PR TITLE
Using indentation string from editor global settings

### DIFF
--- a/lib/atom-amdbutler.js
+++ b/lib/atom-amdbutler.js
@@ -79,11 +79,16 @@ module.exports =  {
     updateWithPairs: function (buffer, pairs) {
         var importsRange = bufferParser.getImportsRange(buffer);
         var paramsRange = bufferParser.getParamsRange(buffer);
+        var indentationSize = atom.config.get('editor.tabLength');
+        var indentationString = '';
+        for (var i = 0; i < indentationSize; i++) {
+          indentationString += ' ';
+        }
 
-        var paramsTxt = zipper.generateParamsTxt(pairs, '    ', false);
+        var paramsTxt = zipper.generateParamsTxt(pairs, indentationString, false);
         buffer.setTextInRange(paramsRange, paramsTxt);
 
-        var importsTxt = zipper.generateImportsTxt(pairs, '    ');
+        var importsTxt = zipper.generateImportsTxt(pairs, indentationString);
         buffer.setTextInRange(importsRange, importsTxt);
     },
     _sort: function (buffer, checkPoint) {


### PR DESCRIPTION
Most js projects use 2 spaces, unfortunately ;)

Could also possibly guess indentation from the current file? This at least makes it configurable.
