### PR TITLE
Replace modulepaths based on paths and package location

### DIFF
--- a/lib/atom-amdbutler.js
+++ b/lib/atom-amdbutler.js
@@ -3,7 +3,7 @@ var crawler = require('./crawler');
 var ModsView = require('./mods-view');
 var bufferParser = require('./buffer-parser');
 var zipper = require('./zipper');
-
+var fs = require('fs');
 
 module.exports =  {
     // settings
@@ -11,6 +11,18 @@ module.exports =  {
         baseFolders: {
             type: 'array',
             'default': ['src'],
+            items: {
+                type: 'string'
+            }
+        },
+        requirejsConfigFile:{
+            type: 'string',
+            'default': 'config.json'
+        },
+        excludePaths:{
+            type: 'array',
+            'default': [],
+            description: 'List of ',
             items: {
                 type: 'string'
             }
@@ -86,6 +98,43 @@ module.exports =  {
         var importsTxt = zipper.generateImportsTxt(pairs, '    ');
         buffer.setTextInRange(importsRange, importsTxt);
     },
+    getReplaceMapFromConfig: function(configFile) {
+        var fileContent;
+        var parsed;
+        try{
+            fileContent = fs.readFileSync(configFile, 'utf8');
+            parsed = JSON.parse(fileContent);
+        } catch(e){
+            console.log('File ' + configFile + ' does not exist, or is not JSON.');
+            return {}; //no file present, return empty map
+        }
+
+        var mapFromPackages = parsed.packages.reduce(function(all, pkg) {
+            all[pkg.location] = pkg.name;
+            return all;
+        }, {});
+
+        var mapFromPathsAndPackages = Object.keys(parsed.paths).reduce(function(all, path) {
+            all[parsed.paths[path]] = path;
+            return all;
+        }, mapFromPackages);
+
+        //sort by length, matching more specific before less
+        var sorted = Object.keys(mapFromPathsAndPackages).sort(function(a, b) {
+            if(a.length > b.length){
+                return -1;
+            }else if(a.length < b.length){
+                return 1;
+            }else{
+                return 0;
+            }
+        }).reduce(function(all, path) {
+            all[path] = mapFromPathsAndPackages[path];
+            return all;
+        }, {});
+
+        return sorted;
+    },
     _sort: function (buffer, checkPoint) {
         this.updateWithPairs(buffer, this.getSortedPairs(buffer));
 
@@ -94,7 +143,8 @@ module.exports =  {
     ensureModulesAreLoaded: function (bufferPath) {
         if (!this.modules) {
             this.modules = crawler.crawl(
-                crawler.getBaseFolderPath(bufferPath, atom.config.get('amdbutler.baseFolders'))
+                crawler.getBaseFolderPath(bufferPath, atom.config.get('amdbutler.baseFolders')),
+                this.getReplaceMapFromConfig(atom.config.get('amdbutler.requirejsConfigFile'))
             );
         }
     },
@@ -109,6 +159,8 @@ module.exports =  {
         var excludes = this.getSortedPairs(buffer).map(function (i) {
             return i.path;
         });
+
+        excludes = excludes.concat(atom.config.get('amdbutler.excludePaths'));
 
         this.modsView.show(this.modules, 'add', excludes);
     },

--- a/lib/atom-amdbutler.js
+++ b/lib/atom-amdbutler.js
@@ -114,6 +114,10 @@ module.exports =  {
             return {}; //no file present, return empty map
         }
 
+        parsed = parsed || {};
+        parsed.paths = parsed.paths || {};
+        parsed.packages = parsed.packages || [];
+
         var mapFromPackages = parsed.packages.reduce(function(all, pkg) {
             all[pkg.location] = pkg.name;
             return all;
@@ -149,7 +153,7 @@ module.exports =  {
         if (!crawler.modules) {
             var baseFolderPath = crawler.getBaseFolderPath(bufferPath, atom.config.get('amdbutler.baseFolders'));
             var currentProject = bufferPath.slice(baseFolderPath.length + 1).split(path.sep)[0];
-            var replaceMap = this.getReplaceMapFromConfig(atom.config.get('amdbutler.requirejsConfigFile'));
+            var replaceMap = this.getReplaceMapFromConfig(path.join(baseFolderPath,  atom.config.get('amdbutler.requirejsConfigFile')));
             crawler.crawl(baseFolderPath, currentProject, replaceMap);
         }
     },
@@ -164,6 +168,8 @@ module.exports =  {
         var excludes = this.getSortedPairs(buffer).map(function (i) {
             return i.path;
         });
+
+        excludes = excludes.concat(['bower_components']);
 
         this.modsView.show(crawler.modules, 'add', excludes);
     },

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -93,9 +93,9 @@ module.exports = {
           return mod.indexOf(key) === 0;
       })[0];
 
-      if(toReplace){
+      if (toReplace) {
           return mod.replace(toReplace, replaceMap[toReplace]);
-      }else{
+      } else {
           return mod;
       }
     },

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -87,6 +87,7 @@ module.exports = {
         }
     },
     getModPath: function (mod, replaceMap) {
+      replaceMap = replaceMap || {};
       var toReplace = Object.keys(replaceMap).filter(function(key) {
           return mod.indexOf(key) === 0;
       })[0];

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -25,7 +25,7 @@ module.exports = {
 
         return path.join(filePath.split(baseFolderName)[0], baseFolderName);
     },
-    crawl: function (basePath) {
+    crawl: function (basePath, replaceMap) {
         var defaultExcludes = ['**/nls/**', '**/tests/**'];
         var options = {
             cwd: basePath,
@@ -36,8 +36,19 @@ module.exports = {
         var that = this;
         return glob.sync('**/*.js', options).map(function (entry) {
             var modPath = entry.slice(0, -3);
-            return {path: modPath, name: that.getParamName(modPath)};
+            return {path: that.getModPath(modPath, replaceMap), rawPath:modPath, name: that.getParamName(modPath)};
         });
+    },
+    getModPath: function (mod, replaceMap) {
+      var toReplace = Object.keys(replaceMap).filter(function(key) {
+          return mod.indexOf(key) === 0;
+      })[0];
+
+      if(toReplace){
+          return mod.replace(toReplace, replaceMap[toReplace]);
+      }else{
+          return mod;
+      }
     },
     getParamName: function (mod) {
         if (Object.keys(ALIASES).indexOf(mod) !== -1) {

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -38,7 +38,7 @@ module.exports = {
 
         var that = this;
         this.modules = glob.sync('**/*.js', options).map(function (entry) {
-            return that.getModuleFromPath(entry, replaceMap);
+            return that.getModuleFromPath(entry, null, replaceMap);
         });
 
         // only watch files in the current package so that we aren't watching all of the
@@ -50,28 +50,28 @@ module.exports = {
             that.watcher = this;
             this.on('added', function (path) {
                 console.log('added: ', path);
-                that.modules.push(that.getModuleFromPath(path, basePath));
+                that.modules.push(that.getModuleFromPath(path, basePath, replaceMap));
             });
             this.on('deleted', function (path) {
                 console.log('deleted: ', path);
-                that.removeModule(path, basePath);
+                that.removeModule(path, basePath, replaceMap);
             });
             this.on('rename', function (newPath, oldPath) {
                 console.log('renamed: ' + oldPath + ' -> ' + newPath);
-                that.removeModule(oldPath, basePath);
-                that.modules.push(that.getModuleFromPath(newPath, basePath));
+                that.removeModule(oldPath, basePath, replaceMap);
+                that.modules.push(that.getModuleFromPath(newPath, basePath, replaceMap));
             });
         });
     },
-    getModuleFromPath: function (entry, basePath) {
+    getModuleFromPath: function (entry, basePath, replaceMap) {
         var modPath = entry.slice(0, -3);
         if (basePath) {
             modPath = modPath.replace(basePath + '/', '');
         }
-        return {path: this.getModPath(modPath), rawPath: modPath, name: this.getParamName(modPath)};
+        return {path: this.getModPath(modPath, replaceMap), rawPath: modPath, name: this.getParamName(modPath)};
     },
-    removeModule: function (entry, basePath) {
-        var mod = this.getModuleFromPath(entry, basePath);
+    removeModule: function (entry, basePath, replaceMap) {
+        var mod = this.getModuleFromPath(entry, basePath, replaceMap);
         var index;
         this.modules.some(function (m, i) {
             if (m.path === mod.path) {

--- a/lib/crawler.js
+++ b/lib/crawler.js
@@ -68,7 +68,8 @@ module.exports = {
         if (basePath) {
             modPath = modPath.replace(basePath + '/', '');
         }
-        return {path: this.getModPath(modPath, replaceMap), rawPath: modPath, name: this.getParamName(modPath)};
+        var rewrittenModPath = this.getModPath(modPath, replaceMap);
+        return {path: rewrittenModPath, rawPath: modPath, name: this.getParamName(rewrittenModPath)};
     },
     removeModule: function (entry, basePath, replaceMap) {
         var mod = this.getModuleFromPath(entry, basePath, replaceMap);

--- a/lib/mods-view.js
+++ b/lib/mods-view.js
@@ -62,7 +62,9 @@ ModsView.prototype.show = function (items, action, excludePaths) {
     }
     this.panel.show();
     this.setItems(items.filter(function (i) {
-        return excludePaths.indexOf(i.path) === -1;
+        return !excludePaths.some(function(pathToExclude) {
+            return i.path.indexOf(pathToExclude) === 0;
+        });
     }));
     return this.focusFilterEditor();
 };

--- a/spec/crawler-spec.js
+++ b/spec/crawler-spec.js
@@ -49,12 +49,24 @@ describe('crawler tests', function () {
         it('returns a module object from a path', function () {
             expect(crawler.getModuleFromPath('app/sub/Hello.js')).toEqual({
                 path: 'app/sub/Hello',
+                rawPath: 'app/sub/Hello',
                 name: 'Hello'
             });
             expect(crawler.getModuleFromPath('/Users/stdavis/Documents/Projects/wri-web/src/app/project/test4.js',
                 '/Users/stdavis/Documents/Projects/wri-web/src')).toEqual({
                 path: 'app/project/test4',
+                rawPath: 'app/project/test4',
                 name: 'test4'
+            });
+        });
+        it('rewrites if passed a matching map', function() {
+            expect(crawler.getModuleFromPath(
+                '/Users/stdavis/Documents/Projects/wri-web/src/app/bower_components/lodash/modern/array/flatten.js',
+                '/Users/stdavis/Documents/Projects/wri-web/src',
+                {'app/bower_components/lodash/modern' : 'lodash'})).toEqual({
+                path: 'lodash/array/flatten',
+                rawPath: 'app/bower_components/lodash/modern/array/flatten',
+                name: 'flatten'
             });
         });
     });

--- a/spec/crawler-spec.js
+++ b/spec/crawler-spec.js
@@ -69,6 +69,16 @@ describe('crawler tests', function () {
                 name: 'flatten'
             });
         });
+        it('rewrites if passed a matching map, and uses correct package name', function() {
+            expect(crawler.getModuleFromPath(
+                '/Users/stdavis/Documents/Projects/wri-web/src/app/bower_components/lodash/modern/foo/string.js',
+                '/Users/stdavis/Documents/Projects/wri-web/src',
+                {'app/bower_components/lodash/modern' : 'lodash'})).toEqual({
+                path: 'lodash/foo/string',
+                rawPath: 'app/bower_components/lodash/modern/foo/string',
+                name: 'lodashString'
+            });
+        });
     });
     describe('removeModule', function () {
         it('removes a module from the list', function () {


### PR DESCRIPTION
Work in Progress. Pretty basic for now, but works. Feedback is welcome!

As mentioned in https://github.com/agrc/atom-amdbutler/pull/17 i have done some work on this.

The way it works now is:
1. New option **requirejsConfigFile**
2. Tries to read and parse as JSON baseFolderPath + requirejsConfigFile, if not ok, fail silently. Will work as before.
3. If ok creates a replace map based on the paths and packages
4. When crawling for modules, returns the rewritten path instead of the full disk path. The path that matches first is used.

The map looks like this:

``` js
{
  "bower_components/lodash-amd/modern": "lodash",
  "bower_components/jquery/dist/jquery": "jquery"
}
```

And is sorted with the longest names first so that 

``` js
{
  "bower_components/durandal/js/plugins": "plugins"
  "bower_components/durandal/js":  "durandal"
}
```

results in "plugins/router" instead of "durandal/plugins/router"

In my app I have among others these packages:

``` js
{
  "packages": [{
    "name": "lodash",
    "location": "bower_components/lodash-amd/modern"
  }, {
    "name": "mout",
    "location": "bower_components/mout/src"
  }]
}
```

Resulting in this as an example:

![image](https://cloud.githubusercontent.com/assets/230877/11494778/f3238566-9805-11e5-8424-ab456a9fb5db.png)

And then imported like this:

``` js
define([
  './startApp',
  'lodash/array/flatten',
], function(
  startApp,
  flatten
) {
  'use strict';
});
```

Possible future options
- [ ] Support several requirejs paths, and will try to open them in order, similar to basepaths
- [ ] Support non JSON config, like requirejs does with it's build (beyond me why, just complicates things) Probably need to use a parser like esprima to do this correctly. For now JSON works for my usecase at least.
- [ ] Support package main files so that **lodash/main.js** file is presented only as **lodash**. Need to support the main property for differently named package mains.
