### PR TITLE
Preselects the word under the cursor if any

### DIFF
--- a/lib/atom-amdbutler.js
+++ b/lib/atom-amdbutler.js
@@ -104,6 +104,11 @@ module.exports =  {
 
         buffer.groupChangesSinceCheckpoint(checkPoint);
     },
+    _getWordUnderCursor: function() {
+        var underCursor = atom.workspace.getActivePaneItem().getWordUnderCursor();
+        var match =  /\w+/i.exec(underCursor);
+        return match && match[0];
+    },
     ensureModulesAreLoaded: function (bufferPath) {
         if (!crawler.modules) {
             var baseFolderPath = crawler.getBaseFolderPath(bufferPath, atom.config.get('amdbutler.baseFolders'));
@@ -123,7 +128,7 @@ module.exports =  {
             return i.path;
         });
 
-        this.modsView.show(crawler.modules, 'add', excludes);
+        this.modsView.show(crawler.modules, 'add', excludes, this._getWordUnderCursor());
     },
     sort: function () {
         console.log('amdbutler:sort');
@@ -137,6 +142,6 @@ module.exports =  {
 
         var buffer = atom.workspace.getActivePaneItem().buffer;
 
-        this.modsView.show(this.getSortedPairs(buffer), 'remove');
+        this.modsView.show(this.getSortedPairs(buffer), 'remove', null, this._getWordUnderCursor());
     }
 };

--- a/lib/mods-view.js
+++ b/lib/mods-view.js
@@ -50,7 +50,7 @@ ModsView.prototype.hide = function () {
     this.panel.hide();
     this.restoreFocus();
 };
-ModsView.prototype.show = function (items, action, excludePaths) {
+ModsView.prototype.show = function (items, action, excludePaths, prefilledInput) {
     console.log('show', arguments);
     excludePaths = (excludePaths) ? excludePaths : [];
     this.action = action;
@@ -64,6 +64,13 @@ ModsView.prototype.show = function (items, action, excludePaths) {
     this.setItems(items.filter(function (i) {
         return excludePaths.indexOf(i.path) === -1;
     }));
+
+    if(prefilledInput){
+        var input = this.filterEditorView.getModel();
+        input.setText(prefilledInput);
+        input.selectAll();
+    }
+
     return this.focusFilterEditor();
 };
 ModsView.prototype.destroy = function () {


### PR DESCRIPTION
Prefills whatever is under the cursor if matching /\w+/i and also selects the word so that you can easily replace it if you want. Can hide this under an option if not wanted default behaviour.

![image](https://cloud.githubusercontent.com/assets/230877/11545235/70795b12-9946-11e5-8c55-9b8a4a713a3b.png)

Could also be done for remove I guess.
